### PR TITLE
fix typo of url

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
           <p className="text-center text-muted-foreground mb-4 sm:mb-8">
             Select sessions from different tracks to create your personal schedule. Sessions run from 10:00 to 18:30.
             <br/>
-            Official Schedule is available at <a href="https://2024.jsconf.jp/schedule"
+            Official Schedule is available at <a href="https://jsconf.jp/2024/schedule/"
                                                  className="text-blue-600">https://jsconf.jp/2024/schedule/</a>
           </p>
           <ScheduleGrid/>


### PR DESCRIPTION
I found typo and fix it.

https://jsconf.jp/2024/schedule/